### PR TITLE
fix/escape-quotes-list-handling #1

### DIFF
--- a/csv_generate_inserts.py
+++ b/csv_generate_inserts.py
@@ -10,7 +10,11 @@ os.makedirs(sql_dir_path, exist_ok=True)
 
 # Função para escapar aspas simples e duplas nos valores
 def escape_quotes(value):
-    return value.replace("'", "''").replace('"', '\"')
+    if isinstance(value, list):
+        # Se o valor for uma lista, processa cada elemento recursivamente
+        return ', '.join([escape_quotes(str(item)) for item in value])
+    # Se não for uma lista, trata como string
+    return str(value).replace("'", "''").replace('"', '\"')
 
 # Iterar sobre todos os arquivos CSV no diretório
 for csv_file_name in os.listdir(csv_dir_path):


### PR DESCRIPTION
Fix: Handle list input in escape_quotes function

The escape_quotes function was raising an AttributeError when encountering a list value because the .replace() method is not available for lists.

This commit modifies the function to check if the input is a list. If it is, it recursively calls escape_quotes for each item in the list and joins them into a comma-separated string. Otherwise, it processes the value as a string as before.